### PR TITLE
Do not initialize Ollama client from env var

### DIFF
--- a/server/cmd/run.go
+++ b/server/cmd/run.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/llm-operator/common/pkg/db"
@@ -100,13 +99,7 @@ func run(ctx context.Context, c *config.Config) error {
 		return err
 	}
 
-	if err := os.Setenv("OLLAMA_HOST", c.OllamaServerAddr); err != nil {
-		return err
-	}
-	o, err := ollama.New()
-	if err != nil {
-		return err
-	}
+	o := ollama.New(c.OllamaServerAddr)
 
 	s3Client := s3.NewClient(c.ObjectStore.S3)
 	e := embedder.New(o, s3Client, vstoreClient)

--- a/server/internal/ollama/client.go
+++ b/server/internal/ollama/client.go
@@ -2,19 +2,21 @@ package ollama
 
 import (
 	"context"
+	"net/http"
+	"net/url"
 
 	"github.com/ollama/ollama/api"
 )
 
 // New returns a new Ollama.
-func New() (*Ollama, error) {
-	client, err := api.ClientFromEnvironment()
-	if err != nil {
-		return nil, err
+func New(addr string) *Ollama {
+	url := &url.URL{
+		Scheme: "http",
+		Host:   addr,
 	}
 	return &Ollama{
-		client: client,
-	}, nil
+		client: api.NewClient(url, http.DefaultClient),
+	}
 }
 
 // Ollama wraps the Ollama client.


### PR DESCRIPTION
Ollama processes env vars from init(), and setting the env var later in the code doesn't work.

https://github.com/ollama/ollama/blob/main/envconfig/config.go#L130